### PR TITLE
test fix flaky testValidateResource

### DIFF
--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestResourceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestResourceAccessor.java
@@ -610,7 +610,7 @@ public class TestResourceAccessor extends AbstractTestClass {
     _configAccessor.setClusterConfig(CLUSTER_NAME, clusterConfig);
 
     // Remove all weight configs in InstanceConfig for testing
-    for (String instance : _instancesMap.get(CLUSTER_NAME)) {
+    for (String instance : _gSetupTool.getClusterManagementTool().getInstancesInCluster(CLUSTER_NAME)) {
       InstanceConfig instanceConfig = _configAccessor.getInstanceConfig(CLUSTER_NAME, instance);
       instanceConfig.setInstanceCapacityMap(Collections.emptyMap());
       _configAccessor.setInstanceConfig(CLUSTER_NAME, instance, instanceConfig);
@@ -625,7 +625,7 @@ public class TestResourceAccessor extends AbstractTestClass {
 
     // Add back weight configurations to all instance configs
     Map<String, Integer> instanceCapacityMap = ImmutableMap.of("FOO", 1000, "BAR", 1000);
-    for (String instance : _instancesMap.get(CLUSTER_NAME)) {
+    for (String instance : _gSetupTool.getClusterManagementTool().getInstancesInCluster(CLUSTER_NAME)) {
       InstanceConfig instanceConfig = _configAccessor.getInstanceConfig(CLUSTER_NAME, instance);
       instanceConfig.setInstanceCapacityMap(instanceCapacityMap);
       _configAccessor.setInstanceConfig(CLUSTER_NAME, instance, instanceConfig);


### PR DESCRIPTION
### Issues



- [x] testValidateResource currently failing on master branch. 
- [x] https://github.com/apache/helix/issues/2717


### Description

- [x] Current assumption is that this is due to the testclass utilizing the _instancesMap variable in AbstractTestClass. However, if there are other tests that add instances to the cluster but do not add it to the _instancesMap as well, then tests that only iterate over _instancesMap may miss instances in the cluster. In this case, we don't set the correct configs and the rebalance fails. 

This may be failing now due to recently added/modified tests that have affected the order that the tests are run, or recently added tests that directly add an instance to the cluster. 

This PR is simply to get the CI passing again. A future PR should look to refactor these tests to ensure we have more isolation between our tests. 

### Tests

- [x] N/A

I've run the CI on my personal branch here to confirm the changes are working:
https://github.com/GrantPSpencer/helix/actions/workflows/Helix-PR-CI.yml?query=branch%3Afresh-fix-testvalidateresource

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
