### PR TITLE
[test PR for CI run] updateInstance flaky test fix 

### DIFF
--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
@@ -560,7 +560,7 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
       idealState.setRebalanceMode(IdealState.RebalanceMode.SEMI_AUTO);
       idealState.setDelayRebalanceEnabled(false);
       idealState.setRebalanceDelay(0);
-      _gSetupTool.getClusterManagementTool().setResourceIdealState(CLUSTER_NAME, resource, idealState);
+      _gSetupTool.getClusterManagementTool().updateIdealState(CLUSTER_NAME, resource, idealState);
     }
 
     // Exit MM


### PR DESCRIPTION
### Issues
changes to updater rather than full set. setting idealstate before cluster may lead to this problem, testing this fix on my personal fork before raising to open source