### PR TITLE
first pass at swapIn state selection respects disabled partitions on swapIn node

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperation.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperation.java
@@ -1141,196 +1141,6 @@ public class TestInstanceOperation extends ZkTestBase {
   }
 
   @Test(dependsOnMethods = "testNodeSwapAddSwapInFirst")
-  public void testDisabledPartitionsBeforeSwapInitiated() throws Exception {
-    System.out.println(
-        "START TestInstanceOperation.testEvacuateWithDisabledPartition() at " + new Date(System.currentTimeMillis()));
-    removeOfflineOrInactiveInstances();
-
-    Map<String, ExternalView> beforeEVs = getEVs();
-
-    // Add instance with InstanceOperation set to UNKNOWN
-    String instanceToSwapOutName = _participants.get(0).getInstanceName();
-    InstanceConfig instanceToSwapOutconfig = _gSetupTool.getClusterManagementTool()
-        .getInstanceConfig(CLUSTER_NAME, instanceToSwapOutName);
-    String instanceToSwapInName = PARTICIPANT_PREFIX + "_" + _nextStartPort;
-
-    addParticipant(instanceToSwapInName, instanceToSwapOutconfig.getLogicalId(LOGICAL_ID),
-        instanceToSwapOutconfig.getDomainAsMap().get(ZONE),
-        InstanceConstants.InstanceOperation.UNKNOWN, -1);
-
-    // Set all partitions to disabled and set instance operation to SWAP_IN
-    InstanceConfig swapInInstanceConfig = _gSetupTool.getClusterManagementTool()
-        .getInstanceConfig(CLUSTER_NAME, instanceToSwapInName);
-    swapInInstanceConfig.setInstanceEnabledForPartition(InstanceConstants.ALL_RESOURCES_DISABLED_PARTITION_KEY,
-        "", false);
-    _gSetupTool.getClusterManagementTool().setInstanceConfig(CLUSTER_NAME, instanceToSwapInName, swapInInstanceConfig);
-    _gSetupTool.getClusterManagementTool().setInstanceOperation(CLUSTER_NAME, instanceToSwapInName,
-        InstanceConstants.InstanceOperation.SWAP_IN);
-    Assert.assertEquals(
-        _gSetupTool.getClusterManagementTool().getInstanceConfig(CLUSTER_NAME, instanceToSwapInName)
-            .getInstanceOperation().getOperation(),
-        InstanceConstants.InstanceOperation.SWAP_IN);
-    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
-
-    // Assert assignment is in IdealState, but all states are offline
-    for (String resource : _allDBs) {
-      IdealState is = _gSetupTool.getClusterManagementTool()
-          .getResourceIdealState(CLUSTER_NAME, resource);
-      ExternalView ev = beforeEVs.get(resource);
-      for (String partition : is.getPartitionSet()) {
-        if (ev.getStateMap(partition).containsKey(instanceToSwapOutName)) {
-          Assert.assertEquals(is.getInstanceStateMap(partition).get(instanceToSwapInName), "OFFLINE");
-        }
-      }
-    }
-
-    // Assert not possible to complete swap (swap in should not have current states)
-    Assert.assertFalse(_gSetupTool.getClusterManagementTool()
-        .canCompleteSwap(CLUSTER_NAME, instanceToSwapOutName));
-
-    // Re-enable all partitions, IS states no longer forced to OFFLINE and swap allowed to complete
-    swapInInstanceConfig = _gSetupTool.getClusterManagementTool()
-        .getInstanceConfig(CLUSTER_NAME, instanceToSwapInName);
-    swapInInstanceConfig.setInstanceEnabledForPartition(InstanceConstants.ALL_RESOURCES_DISABLED_PARTITION_KEY,
-        "", true);
-    _gSetupTool.getClusterManagementTool().setInstanceConfig(CLUSTER_NAME, instanceToSwapInName, swapInInstanceConfig);
-
-    // Assert successfully complete swap
-    Assert.assertTrue(_gSetupTool.getClusterManagementTool().canCompleteSwap(CLUSTER_NAME, instanceToSwapOutName));
-    Assert.assertTrue(_gSetupTool.getClusterManagementTool()
-        .completeSwapIfPossible(CLUSTER_NAME, instanceToSwapOutName, false));
-    Assert.assertTrue(_clusterVerifier.verifyByPolling());
-    validateEVsCorrect(getEVs(), beforeEVs, ImmutableMap.of(instanceToSwapOutName, instanceToSwapInName),
-        Collections.emptySet(), ImmutableSet.of(instanceToSwapInName));
-
-    swapInInstanceConfig = _gSetupTool.getClusterManagementTool()
-        .getInstanceConfig(CLUSTER_NAME, instanceToSwapInName);
-    swapInInstanceConfig.setInstanceEnabledForPartition(InstanceConstants.ALL_RESOURCES_DISABLED_PARTITION_KEY,
-        "", false);
-    _gSetupTool.getClusterManagementTool().setInstanceConfig(CLUSTER_NAME, instanceToSwapInName, swapInInstanceConfig);
-    Assert.assertTrue(_clusterVerifier.verifyByPolling());
-
-    // Assert regular disabled behavior still applies.
-    verifier(() -> {
-      for (String resource : _allDBs) {
-        ExternalView ev = _gSetupTool.getClusterManagementTool().getResourceExternalView(CLUSTER_NAME, resource);
-        for (String partition : ev.getPartitionSet()) {
-          if (ev.getStateMap(partition).containsKey(instanceToSwapInName) && !ev.getStateMap(partition).
-              get(instanceToSwapInName).equals("OFFLINE")) {
-            return false;
-          }
-        }
-      }
-      return true;
-    }, 5000);
-  }
-
-
-  @Test(dependsOnMethods = "testDisabledPartitionsBeforeSwapInitiated")
-  public void testDisabledPartitionsAfterSwapInitiated() throws Exception {
-    System.out.println(
-        "START TestInstanceOperation.testEvacuateWithDisabledPartition() at " + new Date(System.currentTimeMillis()));
-    removeOfflineOrInactiveInstances();
-
-    String swapOutInstanceName = _participants.get(0).getInstanceName();
-    InstanceConfig swapOutInstanceConfig = _gSetupTool.getClusterManagementTool()
-        .getInstanceConfig(CLUSTER_NAME, swapOutInstanceName);
-
-    // Add SWAP_IN instance
-    String swapInInstanceName = PARTICIPANT_PREFIX + "_" + _nextStartPort;
-    addParticipant(swapInInstanceName, swapOutInstanceConfig.getLogicalId(LOGICAL_ID),
-        swapOutInstanceConfig.getDomainAsMap().get(ZONE),
-        InstanceConstants.InstanceOperation.SWAP_IN, -1);
-    Map<String, String> swapOutInstancesToSwapInInstances = new HashMap<>();
-    swapOutInstancesToSwapInInstances.put(swapOutInstanceName, swapInInstanceName);
-    Map<String, ExternalView> beforeSwapAndDisableEVs = getEVs();
-
-    // Assert SWAP_IN taking affect
-    Assert.assertEquals(
-        _gSetupTool.getClusterManagementTool().getInstanceConfig(CLUSTER_NAME, swapInInstanceName)
-            .getInstanceOperation().getOperation(),
-        InstanceConstants.InstanceOperation.SWAP_IN);
-    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
-    Assert.assertTrue(_gSetupTool.getClusterManagementTool().canCompleteSwap(CLUSTER_NAME, swapOutInstanceName));
-
-    // Get current EVs and validate swap proceeding normally
-    Map<String, ExternalView> beforeDisableEVs = getEVs();
-    validateEVsCorrect(beforeDisableEVs, beforeSwapAndDisableEVs, swapOutInstancesToSwapInInstances,
-        ImmutableSet.of(swapInInstanceName), Collections.emptySet());
-
-    // Set all partitions to disabled and set instance operation to SWAP_IN
-    InstanceConfig swapInInstanceConfig = _gSetupTool.getClusterManagementTool()
-        .getInstanceConfig(CLUSTER_NAME, swapInInstanceName);
-    swapInInstanceConfig.setInstanceEnabledForPartition(InstanceConstants.ALL_RESOURCES_DISABLED_PARTITION_KEY,
-        "", false);
-    _gSetupTool.getClusterManagementTool().setInstanceConfig(CLUSTER_NAME, swapInInstanceName, swapInInstanceConfig);
-    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
-
-    // Assert EV is correct - all swap affected partitions will have 1 extra replica in OFFLINE state hosted on SWAP_IN node
-    Map<String, ExternalView> currentEVs = getEVs();
-    for (String resource : _allDBs) {
-      validateEVCorrect(currentEVs.get(resource), beforeDisableEVs.get(resource), swapOutInstancesToSwapInInstances,
-          ImmutableSet.of(swapInInstanceName), Collections.emptySet(), ImmutableSet.of(swapInInstanceName));
-    }
-
-    // Assert not possible to complete swap
-    Assert.assertFalse(_gSetupTool.getClusterManagementTool().canCompleteSwap(CLUSTER_NAME, swapOutInstanceName));
-
-    // Re-enable all partitions, IS states no longer forced to OFFLINE and swap allowed to complete
-    swapInInstanceConfig = _gSetupTool.getClusterManagementTool()
-        .getInstanceConfig(CLUSTER_NAME, swapInInstanceName);
-    swapInInstanceConfig.setInstanceEnabledForPartition(InstanceConstants.ALL_RESOURCES_DISABLED_PARTITION_KEY,
-        "", true);
-    _gSetupTool.getClusterManagementTool().setInstanceConfig(CLUSTER_NAME, swapInInstanceName, swapInInstanceConfig);
-    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
-    Assert.assertTrue(_gSetupTool.getClusterManagementTool().canCompleteSwap(CLUSTER_NAME, swapOutInstanceName));
-    Assert.assertTrue(_gSetupTool.getClusterManagementTool().completeSwapIfPossible(CLUSTER_NAME, swapOutInstanceName,
-        false));
-    Assert.assertTrue(_clusterVerifier.verifyByPolling());
-
-    // Assert swap completed successfully
-    validateEVsCorrect(getEVs(), beforeSwapAndDisableEVs, swapOutInstancesToSwapInInstances,
-        Collections.emptySet(), ImmutableSet.of(swapInInstanceName));
-  }
-
-  @Test(dependsOnMethods = "testDisabledPartitionsAfterSwapInitiated")
-  public void testUnknownDoesNotTriggerRebalance() throws Exception {
-    System.out.println(
-        "START TestInstanceOperation.testUnknownDoesNotTriggerRebalance() at " + new Date(
-            System.currentTimeMillis()));
-
-    // Ensure clean slate
-    removeOfflineOrInactiveInstances();
-    Assert.assertTrue(_clusterVerifier.verifyByPolling());
-
-    Map<String, IdealState> idealStatesBefore = getISs();
-
-    // Add instance with InstanceOperation set to UNKNOWN (should not be considered in placement calculations)
-    String instanceToAdd = PARTICIPANT_PREFIX + "_" + _nextStartPort;
-    addParticipant(instanceToAdd, "foo", "bar", InstanceConstants.InstanceOperation.UNKNOWN, -1);
-    MockParticipantManager testParticipant = _participants.get(_participants.size() - 1);
-    Assert.assertTrue(_clusterVerifier.verifyByPolling());
-
-    // Assert no rebalance
-    Assert.assertEquals(idealStatesBefore, getISs());
-
-    // Assert same no rebalance behavior for node with same logical ID as existing node
-    String instanceToAdd2 = PARTICIPANT_PREFIX + "_" + _nextStartPort;
-    InstanceConfig swapOutInstanceConfig = _gSetupTool.getClusterManagementTool()
-        .getInstanceConfig(CLUSTER_NAME, _participants.get(0).getInstanceName());
-    addParticipant(instanceToAdd2,  swapOutInstanceConfig.getLogicalId(LOGICAL_ID),
-        swapOutInstanceConfig.getDomainAsMap().get(ZONE), InstanceConstants.InstanceOperation.UNKNOWN, -1);
-    Assert.assertTrue(_clusterVerifier.verifyByPolling());
-    Assert.assertEquals(idealStatesBefore, getISs());
-
-
-    // Clean up
-    testParticipant.syncStop();
-    removeOfflineOrInactiveInstances();
-    Assert.assertTrue(_clusterVerifier.verifyByPolling());
-  }
-
-  @Test(dependsOnMethods = "testUnknownDoesNotTriggerRebalance")
   public void testEvacuateAndCancelBeforeBootstrapFinish() throws Exception {
     System.out.println(
         "START TestInstanceOperation.testEvacuateAndCancelBeforeBootstrapFinish() at " + new Date(
@@ -1641,6 +1451,203 @@ public class TestInstanceOperation extends ZkTestBase {
     }
     // Clean up test participant
     toDisableThenEvacuateParticipant.syncStop();
+    removeOfflineOrInactiveInstances();
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+  }
+
+  @Test(dependsOnMethods = "testEvacuateWithDisabledPartition")
+  public void testDisabledPartitionsBeforeSwapInitiated() throws Exception {
+    System.out.println(
+        "START TestInstanceOperation.testEvacuateWithDisabledPartition() at " + new Date(System.currentTimeMillis()));
+    removeOfflineOrInactiveInstances();
+
+    Map<String, ExternalView> beforeEVs = getEVs();
+
+    // Add instance with InstanceOperation set to UNKNOWN
+    String instanceToSwapOutName = _participants.get(0).getInstanceName();
+    InstanceConfig instanceToSwapOutconfig = _gSetupTool.getClusterManagementTool()
+        .getInstanceConfig(CLUSTER_NAME, instanceToSwapOutName);
+    String instanceToSwapInName = PARTICIPANT_PREFIX + "_" + _nextStartPort;
+
+    addParticipant(instanceToSwapInName, instanceToSwapOutconfig.getLogicalId(LOGICAL_ID),
+        instanceToSwapOutconfig.getDomainAsMap().get(ZONE),
+        InstanceConstants.InstanceOperation.UNKNOWN, -1);
+
+    // Set all partitions to disabled and set instance operation to SWAP_IN
+    InstanceConfig swapInInstanceConfig = _gSetupTool.getClusterManagementTool()
+        .getInstanceConfig(CLUSTER_NAME, instanceToSwapInName);
+    swapInInstanceConfig.setInstanceEnabledForPartition(InstanceConstants.ALL_RESOURCES_DISABLED_PARTITION_KEY,
+        "", false);
+    _gSetupTool.getClusterManagementTool().setInstanceConfig(CLUSTER_NAME, instanceToSwapInName, swapInInstanceConfig);
+    _gSetupTool.getClusterManagementTool().setInstanceOperation(CLUSTER_NAME, instanceToSwapInName,
+        InstanceConstants.InstanceOperation.SWAP_IN);
+    Assert.assertEquals(
+        _gSetupTool.getClusterManagementTool().getInstanceConfig(CLUSTER_NAME, instanceToSwapInName)
+            .getInstanceOperation().getOperation(),
+        InstanceConstants.InstanceOperation.SWAP_IN);
+    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+
+    // Assert assignment is in IdealState, but all states are offline
+    for (String resource : _allDBs) {
+      IdealState is = _gSetupTool.getClusterManagementTool()
+          .getResourceIdealState(CLUSTER_NAME, resource);
+      ExternalView ev = beforeEVs.get(resource);
+      for (String partition : is.getPartitionSet()) {
+        if (ev.getStateMap(partition).containsKey(instanceToSwapOutName)) {
+          Assert.assertEquals(is.getInstanceStateMap(partition).get(instanceToSwapInName), "OFFLINE");
+        }
+      }
+    }
+
+    // Assert not possible to complete swap (swap in should not have current states)
+    Assert.assertFalse(_gSetupTool.getClusterManagementTool()
+        .canCompleteSwap(CLUSTER_NAME, instanceToSwapOutName));
+
+    // Re-enable all partitions, IS states no longer forced to OFFLINE and swap allowed to complete
+    swapInInstanceConfig = _gSetupTool.getClusterManagementTool()
+        .getInstanceConfig(CLUSTER_NAME, instanceToSwapInName);
+    swapInInstanceConfig.setInstanceEnabledForPartition(InstanceConstants.ALL_RESOURCES_DISABLED_PARTITION_KEY,
+        "", true);
+    _gSetupTool.getClusterManagementTool().setInstanceConfig(CLUSTER_NAME, instanceToSwapInName, swapInInstanceConfig);
+
+    // Assert successfully complete swap
+    verifier(() -> {
+      return _gSetupTool.getClusterManagementTool().canCompleteSwap(CLUSTER_NAME, instanceToSwapOutName);
+    }, 30000);
+    Assert.assertTrue(_gSetupTool.getClusterManagementTool()
+        .completeSwapIfPossible(CLUSTER_NAME, instanceToSwapOutName, false));
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+    validateEVsCorrect(getEVs(), beforeEVs, ImmutableMap.of(instanceToSwapOutName, instanceToSwapInName),
+        Collections.emptySet(), ImmutableSet.of(instanceToSwapInName));
+
+    swapInInstanceConfig = _gSetupTool.getClusterManagementTool()
+        .getInstanceConfig(CLUSTER_NAME, instanceToSwapInName);
+    swapInInstanceConfig.setInstanceEnabledForPartition(InstanceConstants.ALL_RESOURCES_DISABLED_PARTITION_KEY,
+        "", false);
+    _gSetupTool.getClusterManagementTool().setInstanceConfig(CLUSTER_NAME, instanceToSwapInName, swapInInstanceConfig);
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    // Assert regular disabled behavior still applies.
+    verifier(() -> {
+      for (String resource : _allDBs) {
+        ExternalView ev = _gSetupTool.getClusterManagementTool().getResourceExternalView(CLUSTER_NAME, resource);
+        for (String partition : ev.getPartitionSet()) {
+          if (ev.getStateMap(partition).containsKey(instanceToSwapInName) && !ev.getStateMap(partition).
+              get(instanceToSwapInName).equals("OFFLINE")) {
+            return false;
+          }
+        }
+      }
+      return true;
+    }, 5000);
+  }
+
+  @Test(dependsOnMethods = "testDisabledPartitionsBeforeSwapInitiated")
+  public void testDisabledPartitionsAfterSwapInitiated() throws Exception {
+    System.out.println(
+        "START TestInstanceOperation.testEvacuateWithDisabledPartition() at " + new Date(System.currentTimeMillis()));
+    removeOfflineOrInactiveInstances();
+
+    String swapOutInstanceName = _participants.get(0).getInstanceName();
+    InstanceConfig swapOutInstanceConfig = _gSetupTool.getClusterManagementTool()
+        .getInstanceConfig(CLUSTER_NAME, swapOutInstanceName);
+
+    // Add SWAP_IN instance
+    String swapInInstanceName = PARTICIPANT_PREFIX + "_" + _nextStartPort;
+    addParticipant(swapInInstanceName, swapOutInstanceConfig.getLogicalId(LOGICAL_ID),
+        swapOutInstanceConfig.getDomainAsMap().get(ZONE),
+        InstanceConstants.InstanceOperation.SWAP_IN, -1);
+    Map<String, String> swapOutInstancesToSwapInInstances = new HashMap<>();
+    swapOutInstancesToSwapInInstances.put(swapOutInstanceName, swapInInstanceName);
+    Map<String, ExternalView> beforeSwapAndDisableEVs = getEVs();
+
+    // Assert SWAP_IN taking affect
+    Assert.assertEquals(
+        _gSetupTool.getClusterManagementTool().getInstanceConfig(CLUSTER_NAME, swapInInstanceName)
+            .getInstanceOperation().getOperation(),
+        InstanceConstants.InstanceOperation.SWAP_IN);
+    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+    Assert.assertTrue(_gSetupTool.getClusterManagementTool().canCompleteSwap(CLUSTER_NAME, swapOutInstanceName));
+
+    // Get current EVs and validate swap proceeding normally
+    Map<String, ExternalView> beforeDisableEVs = getEVs();
+    validateEVsCorrect(beforeDisableEVs, beforeSwapAndDisableEVs, swapOutInstancesToSwapInInstances,
+        ImmutableSet.of(swapInInstanceName), Collections.emptySet());
+
+    // Set all partitions to disabled and set instance operation to SWAP_IN
+    InstanceConfig swapInInstanceConfig = _gSetupTool.getClusterManagementTool()
+        .getInstanceConfig(CLUSTER_NAME, swapInInstanceName);
+    swapInInstanceConfig.setInstanceEnabledForPartition(InstanceConstants.ALL_RESOURCES_DISABLED_PARTITION_KEY,
+        "", false);
+    _gSetupTool.getClusterManagementTool().setInstanceConfig(CLUSTER_NAME, swapInInstanceName, swapInInstanceConfig);
+    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+
+    // Assert EV is correct - all swap affected partitions will have 1 extra replica in OFFLINE state hosted on SWAP_IN node
+    Map<String, ExternalView> currentEVs = getEVs();
+    for (String resource : _allDBs) {
+      validateEVCorrect(currentEVs.get(resource), beforeDisableEVs.get(resource), swapOutInstancesToSwapInInstances,
+          ImmutableSet.of(swapInInstanceName), Collections.emptySet(), ImmutableSet.of(swapInInstanceName));
+    }
+
+    // Assert not possible to complete swap
+    Assert.assertFalse(_gSetupTool.getClusterManagementTool().canCompleteSwap(CLUSTER_NAME, swapOutInstanceName));
+
+    // Re-enable all partitions, IS states no longer forced to OFFLINE and swap allowed to complete
+    swapInInstanceConfig = _gSetupTool.getClusterManagementTool()
+        .getInstanceConfig(CLUSTER_NAME, swapInInstanceName);
+    swapInInstanceConfig.setInstanceEnabledForPartition(InstanceConstants.ALL_RESOURCES_DISABLED_PARTITION_KEY,
+        "", true);
+    _gSetupTool.getClusterManagementTool().setInstanceConfig(CLUSTER_NAME, swapInInstanceName, swapInInstanceConfig);
+    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+    Assert.assertTrue(_gSetupTool.getClusterManagementTool().canCompleteSwap(CLUSTER_NAME, swapOutInstanceName));
+    Assert.assertTrue(_gSetupTool.getClusterManagementTool().completeSwapIfPossible(CLUSTER_NAME, swapOutInstanceName,
+        false));
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    // Assert swap completed successfully
+    validateEVsCorrect(getEVs(), beforeSwapAndDisableEVs, swapOutInstancesToSwapInInstances,
+        Collections.emptySet(), ImmutableSet.of(swapInInstanceName));
+    removeOfflineOrInactiveInstances();
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+  }
+
+  @Test(dependsOnMethods = "testDisabledPartitionsAfterSwapInitiated")
+  public void testUnknownDoesNotTriggerRebalance() throws Exception {
+    System.out.println(
+        "START TestInstanceOperation.testUnknownDoesNotTriggerRebalance() at " + new Date(
+            System.currentTimeMillis()));
+
+    // Ensure clean slate
+    removeOfflineOrInactiveInstances();
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    Map<String, IdealState> idealStatesBefore = getISs();
+
+    // Add instance with InstanceOperation set to UNKNOWN (should not be considered in placement calculations)
+    String instanceToAdd = PARTICIPANT_PREFIX + "_" + _nextStartPort;
+    addParticipant(instanceToAdd, "foo", "bar", InstanceConstants.InstanceOperation.UNKNOWN, -1);
+    List<MockParticipantManager> testParticipants = new ArrayList<>();
+    testParticipants.add(_participants.get(_participants.size() - 1));
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    // Assert no rebalance
+    Assert.assertEquals(idealStatesBefore, getISs());
+
+    // Assert same no rebalance behavior for node with same logical ID as existing node
+    String instanceToAdd2 = PARTICIPANT_PREFIX + "_" + _nextStartPort;
+    InstanceConfig swapOutInstanceConfig = _gSetupTool.getClusterManagementTool()
+        .getInstanceConfig(CLUSTER_NAME, _participants.get(0).getInstanceName());
+    addParticipant(instanceToAdd2,  swapOutInstanceConfig.getLogicalId(LOGICAL_ID),
+        swapOutInstanceConfig.getDomainAsMap().get(ZONE), InstanceConstants.InstanceOperation.UNKNOWN, -1);
+    testParticipants.add(_participants.get(_participants.size() - 1));
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+    Assert.assertEquals(idealStatesBefore, getISs());
+
+
+    // Clean up
+    for (MockParticipantManager participant : testParticipants) {
+      participant.syncStop();
+    }
     removeOfflineOrInactiveInstances();
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
   }

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperation.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperation.java
@@ -1125,6 +1125,8 @@ public class TestInstanceOperation extends ZkTestBase {
   public void testSwapEvacuateAdd() throws Exception {
     System.out.println("START TestInstanceOperation.testSwapEvacuateAdd() at " + new Date(
         System.currentTimeMillis()));
+    removeOfflineOrInactiveInstances();
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
     // Store original EV
     Map<String, ExternalView> originalEVs = getEVs();
@@ -1291,6 +1293,7 @@ public class TestInstanceOperation extends ZkTestBase {
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
     validateEVsCorrect(getEVs(), beforeEVs, swapOutInstancesToSwapInInstances, Collections.emptySet(),
         ImmutableSet.of(instanceToSwapInName));
+    _participants.get(_participants.size()-1).syncStop();
   }
 
   @Test(dependsOnMethods = "testDisabledPartitionsBeforeSwapInitiated")
@@ -1362,6 +1365,7 @@ public class TestInstanceOperation extends ZkTestBase {
     // Assert swap completed successfully
     validateEVsCorrect(getEVs(), beforeSwapAndDisableEVs, swapOutInstancesToSwapInInstances,
         Collections.emptySet(), ImmutableSet.of(swapInInstanceName));
+    _participants.get(_participants.size()-1).syncStop();
   }
 
   @Test(dependsOnMethods = "testDisabledPartitionsAfterSwapInitiated")

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperation.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperation.java
@@ -1248,6 +1248,9 @@ public class TestInstanceOperation extends ZkTestBase {
         "", false);
     _gSetupTool.getClusterManagementTool().setInstanceConfig(CLUSTER_NAME, swapInInstanceName, swapInInstanceConfig);
     Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+    // Assert not possible to complete swap (swap in should not have intended current states)
+    Assert.assertFalse(_gSetupTool.getClusterManagementTool()
+        .canCompleteSwap(CLUSTER_NAME, swapOutInstanceName));
 
     // Assert EV is correct - all swap affected partitions will have 1 extra replica in OFFLINE state hosted on SWAP_IN node
     Map<String, ExternalView> currentEVs = getEVs();


### PR DESCRIPTION
swap in state selection will always choose OFFLINE state if the partition is disabled on the swapIn node

Because of this there are 2 behaviors:
disable ALL_RESOURCES --> swap_in the node --> IS says offline --> no resource assignments for swapIn node, because IS was never anything but offline

swap_in the node -->  swapIn node gets assignments --> then disable ALL_RESOURCES --> IS says offline --> swapIn node has assignments but they are all pushed down to OFFLINE
