### PR TITLE
[DRAFT PR] WAGED Instance Capacity NPE

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedInstanceCapacity.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedInstanceCapacity.java
@@ -203,6 +203,13 @@ public class WagedInstanceCapacity implements InstanceCapacityDataProvider {
 
     Map<String, Integer> instanceCapacity = _instanceCapacityMap.get(instance);
     Map<String, Integer> processedCapacity = new HashMap<>();
+
+    // Previously seen NPE when calling instanceCapacity.keySet(). This is a log to help debug future occurrences.
+    if (instanceCapacity == null) {
+      LOG.error("Instance: " + instance + " has no capacity configured. Instances in map are: "
+          + _instanceCapacityMap.keySet());
+    }
+
     for (String key : instanceCapacity.keySet()) {
       if (partitionCapacity.containsKey(key)) {
         int partCapacity = partitionCapacity.get(key);

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedInstanceCapacity.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedInstanceCapacity.java
@@ -203,13 +203,6 @@ public class WagedInstanceCapacity implements InstanceCapacityDataProvider {
 
     Map<String, Integer> instanceCapacity = _instanceCapacityMap.get(instance);
     Map<String, Integer> processedCapacity = new HashMap<>();
-
-    // Previously seen NPE when calling instanceCapacity.keySet(). This is a log to help debug future occurrences.
-    if (instanceCapacity == null) {
-      LOG.error("Instance: " + instance + " has no capacity configured. Instances in map are: "
-          + _instanceCapacityMap.keySet());
-    }
-
     for (String key : instanceCapacity.keySet()) {
       if (partitionCapacity.containsKey(key)) {
         int partCapacity = partitionCapacity.get(key);

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/CurrentStateComputationStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/CurrentStateComputationStage.java
@@ -364,10 +364,6 @@ public class CurrentStateComputationStage extends AbstractBaseStage {
         .filter(entry -> WagedValidationUtil.isWagedEnabled(cache.getIdealState(entry.getKey())))
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
-    if (wagedEnabledResourceMap.isEmpty()) {
-      return;
-    }
-
     // Phase 1: Rebuild Always
     WagedInstanceCapacity capacityProvider = new WagedInstanceCapacity(cache);
     WagedResourceWeightsProvider weightProvider = new WagedResourceWeightsProvider(cache);
@@ -385,7 +381,7 @@ public class CurrentStateComputationStage extends AbstractBaseStage {
    */
   static boolean skipCapacityCalculation(ResourceControllerDataProvider cache, Map<String, Resource> resourceMap,
       ClusterEvent event) {
-    if (resourceMap == null || resourceMap.isEmpty()) {
+    if (resourceMap == null) {
       return true;
     }
 

--- a/helix-core/src/test/java/org/apache/helix/integration/TestWagedNPE.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestWagedNPE.java
@@ -1,0 +1,124 @@
+package org.apache.helix.integration;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import org.apache.helix.ConfigAccessor;
+import org.apache.helix.TestHelper;
+import org.apache.helix.common.ZkTestBase;
+import org.apache.helix.controller.rebalancer.waged.WagedRebalancer;
+import org.apache.helix.integration.manager.ClusterControllerManager;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.model.ResourceConfig;
+import org.apache.helix.tools.ClusterVerifiers.BestPossibleExternalViewVerifier;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class TestWagedNPE extends ZkTestBase  {
+
+  public static String CLUSTER_NAME = TestHelper.getTestClassName() + "_cluster";
+  public static int PARTICIPANT_COUNT = 10;
+  public static List<MockParticipantManager> _participants = new ArrayList<>();
+  public static ClusterControllerManager _controller;
+  public static ConfigAccessor _configAccessor;
+
+  @BeforeClass
+  public void beforeClass() {
+    System.out.println("Start test " + TestHelper.getTestClassName());
+    _gSetupTool.addCluster(CLUSTER_NAME, true);
+    for (int i = 0; i < PARTICIPANT_COUNT; i++) {
+      addParticipant("localhost_" + i);
+    }
+
+    String controllerName = CONTROLLER_PREFIX + "_0";
+    _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, controllerName);
+    _controller.syncStart();
+
+    _configAccessor = new ConfigAccessor(_gZkClient);
+    ClusterConfig clusterConfig =  _configAccessor.getClusterConfig(CLUSTER_NAME);
+    String testCapacityKey = "TestCapacityKey";
+    clusterConfig.setInstanceCapacityKeys(Collections.singletonList(testCapacityKey));
+    clusterConfig.setDefaultInstanceCapacityMap(Collections.singletonMap(testCapacityKey, 100));
+    clusterConfig.setDefaultPartitionWeightMap(Collections.singletonMap(testCapacityKey, 1));
+    _configAccessor.setClusterConfig(CLUSTER_NAME, clusterConfig);
+  }
+
+  @Test
+  public void testNPE() throws Exception {
+    String firstDB = "firstDB";
+    int numPartition = 10;
+    _gSetupTool.addResourceToCluster(CLUSTER_NAME, firstDB, numPartition, "LeaderStandby",
+        IdealState.RebalanceMode.FULL_AUTO.name(), null);
+
+    IdealState idealStateOne =
+        _gSetupTool.getClusterManagementTool().getResourceIdealState(CLUSTER_NAME, firstDB);
+    idealStateOne.setMinActiveReplicas(2);
+    idealStateOne.setRebalancerClassName(WagedRebalancer.class.getName());
+    _gSetupTool.getClusterManagementTool().setResourceIdealState(CLUSTER_NAME, firstDB, idealStateOne);
+    _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, firstDB, 3);
+
+    BestPossibleExternalViewVerifier verifier =
+        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkAddr(ZK_ADDR)
+            .setResources(Collections.singleton(firstDB))
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME).build();
+
+    Assert.assertTrue(verifier.verifyByPolling());
+
+    // drop resource
+    _gSetupTool.dropResourceFromCluster(CLUSTER_NAME, firstDB);
+
+    // add instance
+    MockParticipantManager participantToAdd = addParticipant("instance_to_add");
+     verifier =
+        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkAddr(ZK_ADDR)
+            .setResources(new HashSet<>(_gSetupTool.getClusterManagementTool().getResourcesInCluster(CLUSTER_NAME)))
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME).build();
+    Assert.assertTrue(verifier.verifyByPolling());
+
+    // add resource again
+    String secondDb = "secondDB";
+    _configAccessor.setResourceConfig(CLUSTER_NAME, secondDb, new ResourceConfig(secondDb));
+    _gSetupTool.addResourceToCluster(CLUSTER_NAME, secondDb, numPartition, "LeaderStandby",
+        IdealState.RebalanceMode.FULL_AUTO.name(), null);
+    IdealState idealStateTwo =
+        _gSetupTool.getClusterManagementTool().getResourceIdealState(CLUSTER_NAME, secondDb);
+    idealStateTwo.setMinActiveReplicas(2);
+    idealStateTwo.setRebalancerClassName(WagedRebalancer.class.getName());
+    _gSetupTool.getClusterManagementTool().setResourceIdealState(CLUSTER_NAME, secondDb, idealStateTwo);
+    _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, secondDb, 3);
+
+
+    verifier =
+        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkAddr(ZK_ADDR)
+            .setResources(Collections.singleton(secondDb))
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME).build();
+    Assert.assertTrue(verifier.verifyByPolling());
+  }
+
+  public MockParticipantManager addParticipant(String instanceName) {
+    _gSetupTool.addInstanceToCluster(CLUSTER_NAME, instanceName);
+    MockParticipantManager participant = new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, instanceName);
+    participant.syncStart();
+    _participants.add(participant);
+    return participant;
+  }
+
+  public void dropParticipant(String instanceName) {
+    MockParticipantManager participantToDrop = _participants.stream()
+        .filter(p -> p.getInstanceName().equals(instanceName)).findFirst().get();
+    dropParticipant(participantToDrop);
+
+  }
+
+  public void dropParticipant(MockParticipantManager participantToDrop) {
+    participantToDrop.syncStop();
+    _gSetupTool.getClusterManagementTool().dropInstance(CLUSTER_NAME,
+        _gSetupTool.getClusterManagementTool().getInstanceConfig(CLUSTER_NAME, participantToDrop.getInstanceName()));
+    _participants.remove(participantToDrop);
+  }
+}


### PR DESCRIPTION
waged isntance capacity is not recalculated when a new resource is added when it is the only resource in the cluster. 
This is because it is only recalcalculated on resourceConfigChange and not IdealStateChange (this would cause a lot of recalculations). resourceConfigChange will trigger when a new resource is added, but the resourceMap will be empty because it is built from the resource's idealState which has not been calculated yet. 

This change recalculates the capacity map even when there are no waged resources detected. TODO: WE NEED TO DETERMINE HOW TO KEEP THE OPTIMIZATION OF NOT CALCULATING WHEN THERE ARE NO WAGED ENABLED RESOURCES (AKA ONLY CRUSHED RESOURCES), BUT NEED TO ACCOUNT FOR THAT NEW RESOURCE WONT BE IN RESOURCEMAP WHEN THIS RESOURCECONFIGCHANGE EVENT IS PROCESSED