### PR TITLE
[TEST PR FOR CI] IntermediateState NPE

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/IntermediateStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/IntermediateStateCalcStage.java
@@ -865,7 +865,7 @@ public class IntermediateStateCalcStage extends AbstractBaseStage {
         if (!value.getToState().equals(HelixDefinedState.DROPPED.name())) {
           intermediateStateMap.setState(entry.getKey(), value.getTgtName(), value.getToState());
         } else if (intermediateStateMap.getStateMap().containsKey(entry.getKey())) {
-            intermediateStateMap.getStateMap().get(entry.getKey()).remove(value.getTgtName());
+          intermediateStateMap.getStateMap().get(entry.getKey()).remove(value.getTgtName());
         }
       });
     }

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/IntermediateStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/IntermediateStateCalcStage.java
@@ -865,7 +865,9 @@ public class IntermediateStateCalcStage extends AbstractBaseStage {
         if (!value.getToState().equals(HelixDefinedState.DROPPED.name())) {
           intermediateStateMap.setState(entry.getKey(), value.getTgtName(), value.getToState());
         } else {
-          intermediateStateMap.getStateMap().get(entry.getKey()).remove(value.getTgtName());
+          if (intermediateStateMap.getStateMap().containsKey(entry.getKey())) {
+            intermediateStateMap.getStateMap().get(entry.getKey()).remove(value.getTgtName());
+          }
         }
       });
     }

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/IntermediateStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/IntermediateStateCalcStage.java
@@ -864,10 +864,8 @@ public class IntermediateStateCalcStage extends AbstractBaseStage {
       entry.getValue().forEach((key, value) -> {
         if (!value.getToState().equals(HelixDefinedState.DROPPED.name())) {
           intermediateStateMap.setState(entry.getKey(), value.getTgtName(), value.getToState());
-        } else {
-          if (intermediateStateMap.getStateMap().containsKey(entry.getKey())) {
+        } else if (intermediateStateMap.getStateMap().containsKey(entry.getKey())) {
             intermediateStateMap.getStateMap().get(entry.getKey()).remove(value.getTgtName());
-          }
         }
       });
     }


### PR DESCRIPTION
NPE occuring during intermrediate state calc stage. Likely this occurs when:
1. Resource has partition with 1 replica
2. Message is sent to instance A to drop replica, but replica does not exist in instance's current state anymore. 
3. Controller snapshots cluster and runs pipeline 
4. IntermediateStateCalc will attempt to call .remove() on a StateMap that does not exist

Possibly the above can occur if:
1. Node goes offline so no current state (?? need to confirm this)
2. Or race condition where node reads the message, drops the current state, but hasn't deleted the message yet so it is still seen as a pending message

```
2024/10/29 01:48:13.046 ERROR [GenericHelixController] [HelixController-pipeline-default-CLUSTERNAME-(70ae9461_DEFAULT)] [helix] [] Exception while executing DEFAULT pipeline for cluster CLUSTERNAME. Will not continue to next pipeline
java.lang.NullPointerException: null
        at org.apache.helix.controller.stages.IntermediateStateCalcStage.lambda$computeIntermediateMap$2(IntermediateStateCalcStage.java:868) ~[org.apache.helix.helix-core-1.3.2-dev-202404301535-hotfix.jar:1.3.2-dev-202404301535-hotfix]
        at java.util.HashMap.forEach(HashMap.java:1337) ~[?:?]
        at org.apache.helix.controller.stages.IntermediateStateCalcStage.computeIntermediateMap(IntermediateStateCalcStage.java:864) ~[org.apache.helix.helix-core-1.3.2-dev-202404301535-hotfix.jar:1.3.2-dev-202404301535-hotfix]
        at org.apache.helix.controller.stages.IntermediateStateCalcStage.computeIntermediatePartitionState(IntermediateStateCalcStage.java:402) ~[org.apache.helix.helix-core-1.3.2-dev-202404301535-hotfix.jar:1.3.2-dev-202404301535-hotfix]
        at org.apache.helix.controller.stages.IntermediateStateCalcStage.compute(IntermediateStateCalcStage.java:180) ~[org.apache.helix.helix-core-1.3.2-dev-202404301535-hotfix.jar:1.3.2-dev-202404301535-hotfix]
        at org.apache.helix.controller.stages.IntermediateStateCalcStage.process(IntermediateStateCalcStage.java:85) ~[org.apache.helix.helix-core-1.3.2-dev-202404301535-hotfix.jar:1.3.2-dev-202404301535-hotfix]
        at org.apache.helix.controller.pipeline.Pipeline.handle(Pipeline.java:75) ~[org.apache.helix.helix-core-1.3.2-dev-202404301535-hotfix.jar:1.3.2-dev-202404301535-hotfix]
        at org.apache.helix.controller.GenericHelixController.handleEvent(GenericHelixController.java:903) [org.apache.helix.helix-core-1.3.2-dev-202404301535-hotfix.jar:1.3.2-dev-202404301535-hotfix]
        at org.apache.helix.controller.GenericHelixController$ClusterEventProcessor.run(GenericHelixController.java:1554) [org.apache.helix.helix-core-1.3.2-dev-202404301535-hotfix.jar:1.3.2-dev-202404301535-hotfix]

```