### PR TITLE
[TEST PR]thread safe assignment metadata

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/AssignmentManager.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/AssignmentManager.java
@@ -55,7 +55,7 @@ class AssignmentManager {
     if (assignmentMetadataStore != null) {
       try {
         _stateReadLatency.startMeasuringLatency();
-        currentBaseline = new HashMap<>(assignmentMetadataStore.getBaseline());
+        currentBaseline = assignmentMetadataStore.getBaseline();
         _stateReadLatency.endMeasuringLatency();
       } catch (Exception ex) {
         throw new HelixRebalanceException(
@@ -88,10 +88,7 @@ class AssignmentManager {
     if (assignmentMetadataStore != null) {
       try {
         _stateReadLatency.startMeasuringLatency();
-        currentBestAssignment =
-            assignmentMetadataStore.getBestPossibleAssignment().entrySet().stream().collect(
-                Collectors.toMap(Map.Entry::getKey,
-                    entry -> new ResourceAssignment(entry.getValue().getRecord())));
+        currentBestAssignment = assignmentMetadataStore.getBestPossibleAssignment();
         ;
         _stateReadLatency.endMeasuringLatency();
       } catch (Exception ex) {

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/AssignmentMetadataStore.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/AssignmentMetadataStore.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import java.util.Objects;
-import java.util.stream.Collectors;
 import org.apache.helix.BucketDataAccessor;
 import org.apache.helix.HelixException;
 import org.apache.helix.HelixProperty;
@@ -79,9 +78,11 @@ public class AssignmentMetadataStore {
         }
       }
     }
-    return _globalBaseline.entrySet().stream().collect(
-        Collectors.toMap(Map.Entry::getKey,
-            entry -> new ResourceAssignment(entry.getValue().getRecord())));
+    Map<String, ResourceAssignment> result = new HashMap<>(_globalBaseline.size());
+    for (Map.Entry<String, ResourceAssignment> entry : _globalBaseline.entrySet()) {
+      result.put(entry.getKey(), new ResourceAssignment(entry.getValue().getRecord()));
+    }
+    return result;
   }
 
   /**
@@ -108,9 +109,11 @@ public class AssignmentMetadataStore {
       }
     }
     // Return defensive copy so that the in-memory assignment is not modified by callers
-    return _bestPossibleAssignment.entrySet().stream().collect(
-        Collectors.toMap(Map.Entry::getKey,
-            entry -> new ResourceAssignment(entry.getValue().getRecord())));
+    Map<String, ResourceAssignment> result = new HashMap<>(_bestPossibleAssignment);
+    for (Map.Entry<String, ResourceAssignment> entry : _bestPossibleAssignment.entrySet()) {
+      result.put(entry.getKey(), new ResourceAssignment(entry.getValue().getRecord()));
+    }
+    return result;
   }
 
   private Map<String, ResourceAssignment> fetchAssignmentOrDefault(String path) {
@@ -147,9 +150,11 @@ public class AssignmentMetadataStore {
    */
   public synchronized void persistBaseline(Map<String, ResourceAssignment> globalBaseline) {
     // Create defensive copy so that the in-memory assignment is not modified after it is persisted
-    Map<String, ResourceAssignment> baselineCopy = globalBaseline.entrySet().stream().collect(
-        Collectors.toMap(Map.Entry::getKey,
-            entry -> new ResourceAssignment(entry.getValue().getRecord())));
+    Map<String, ResourceAssignment> baselineCopy = new HashMap<>(globalBaseline.size());
+    for (Map.Entry<String, ResourceAssignment> entry : globalBaseline.entrySet()) {
+      baselineCopy.put(entry.getKey(), new ResourceAssignment(entry.getValue().getRecord()));
+    }
+
     // write to metadata store
     persistAssignmentToMetadataStore(baselineCopy, _baselinePath, BASELINE_KEY);
     // write to memory
@@ -163,9 +168,10 @@ public class AssignmentMetadataStore {
    */
   public synchronized void persistBestPossibleAssignment(Map<String, ResourceAssignment> bestPossibleAssignment) {
     // Create defensive copy so that the in-memory assignment is not modified after it is persisted
-    Map<String, ResourceAssignment> bestPossibleAssignmentCopy = bestPossibleAssignment.entrySet().stream().collect(
-        Collectors.toMap(Map.Entry::getKey,
-            entry -> new ResourceAssignment(entry.getValue().getRecord())));
+    Map<String, ResourceAssignment> bestPossibleAssignmentCopy = new HashMap<>(bestPossibleAssignment.size());
+    for (Map.Entry<String, ResourceAssignment> entry : bestPossibleAssignment.entrySet()) {
+      bestPossibleAssignmentCopy.put(entry.getKey(), new ResourceAssignment(entry.getValue().getRecord()));
+    }
     // write to metadata store
     persistAssignmentToMetadataStore(bestPossibleAssignmentCopy, _bestPossiblePath, BEST_POSSIBLE_KEY);
     // write to memory
@@ -183,9 +189,10 @@ public class AssignmentMetadataStore {
    */
   public synchronized boolean asyncUpdateBestPossibleAssignmentCache(
       Map<String, ResourceAssignment> bestPossibleAssignment, int newVersion) {
-    Map<String, ResourceAssignment> bestPossibleAssignmentCopy = bestPossibleAssignment.entrySet().stream().collect(
-        Collectors.toMap(Map.Entry::getKey,
-            entry -> new ResourceAssignment(entry.getValue().getRecord())));
+    Map<String, ResourceAssignment> bestPossibleAssignmentCopy = new HashMap<>(bestPossibleAssignment.size());
+    for (Map.Entry<String, ResourceAssignment> entry : bestPossibleAssignment.entrySet()) {
+      bestPossibleAssignmentCopy.put(entry.getKey(), new ResourceAssignment(entry.getValue().getRecord()));
+    }
     // Check if the version is stale by this point
     if (newVersion > _bestPossibleVersion) {
       _bestPossibleAssignment = bestPossibleAssignmentCopy;

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/MockAssignmentMetadataStore.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/MockAssignmentMetadataStore.java
@@ -19,7 +19,7 @@ package org.apache.helix.controller.rebalancer.waged;
  * under the License.
  */
 
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.helix.BucketDataAccessor;
@@ -36,7 +36,7 @@ public class MockAssignmentMetadataStore extends AssignmentMetadataStore {
   }
 
   public Map<String, ResourceAssignment> getBaseline() {
-    return _globalBaseline == null ? Collections.emptyMap() : _globalBaseline;
+    return _globalBaseline == null ? new HashMap<>() : _globalBaseline;
   }
 
   public void persistBaseline(Map<String, ResourceAssignment> globalBaseline) {
@@ -44,7 +44,7 @@ public class MockAssignmentMetadataStore extends AssignmentMetadataStore {
   }
 
   public Map<String, ResourceAssignment> getBestPossibleAssignment() {
-    return _bestPossibleAssignment == null ? Collections.emptyMap() : _bestPossibleAssignment;
+    return _bestPossibleAssignment == null ? new HashMap<>() : _bestPossibleAssignment;
   }
 
   public void persistBestPossibleAssignment(


### PR DESCRIPTION
### Issues
Refactor how we get and persist assignment data to prevent concurrent modification errors. 
It can happen that the async partial rebalance thread updates the best possible assignment (gets and clears the mapping) while the assignmentManager called by the sync emergencyRebalance is iterating over it in order to create a deep copy

This PR makes it so that get will always return a deep copy and set creates a deep copy so that methods can safely iterate over and/or modify the map that was returned from getAssignment or passed into persistAssignment

Updating the map can be done simply by pointing the _bestpossible or _baseline at the new map object to prevent slowdown from creating a deepcopy on each get

```
2025/03/24 20:00:06.938 ERROR [BestPossibleStateCalcStage] [HelixController-pipeline-default-ESPRESSO_MT2-(39f24f68_DEFAULT)] [helix] [] Event 39f24f68_DEFAULT : Failed to calculate the new Ideal States using the rebalancer WagedRebalancer due to INVALID_REBALANCER_STATUS
org.apache.helix.HelixRebalanceException: Failed to get the current best possible assignment because of unexpected error. Failure Type: INVALID_REBALANCER_STATUS
        at org.apache.helix.controller.rebalancer.waged.AssignmentManager.getBestPossibleAssignment(AssignmentManager.java:98) ~[org.apache.helix.helix-core-1.4.3-dev-202502211050.jar:1.4.3-dev-202502211050]
        at org.apache.helix.controller.rebalancer.waged.WagedRebalancer.emergencyRebalance(WagedRebalancer.java:456) ~[org.apache.helix.helix-core-1.4.3-dev-202502211050.jar:1.4.3-dev-202502211050]
        at org.apache.helix.controller.rebalancer.waged.WagedRebalancer.computeBestPossibleAssignment(WagedRebalancer.java:339) ~[org.apache.helix.helix-core-1.4.3-dev-202502211050.jar:1.4.3-dev-202502211050]
        at org.apache.helix.controller.rebalancer.waged.WagedRebalancer.computeBestPossibleStates(WagedRebalancer.java:316) ~[org.apache.helix.helix-core-1.4.3-dev-202502211050.jar:1.4.3-dev-202502211050]
        at org.apache.helix.controller.rebalancer.waged.WagedRebalancer.computeNewIdealStates(WagedRebalancer.java:248) ~[org.apache.helix.helix-core-1.4.3-dev-202502211050.jar:1.4.3-dev-202502211050]
        at org.apache.helix.controller.stages.BestPossibleStateCalcStage.computeResourceBestPossibleStateWithWagedRebalancer(BestPossibleStateCalcStage.java:445) [org.apache.helix.helix-core-1.4.3-dev-202502211050.jar:1.4.3-dev-202502211050]         at org.apache.helix.controller.stages.BestPossibleStateCalcStage.compute(BestPossibleStateCalcStage.java:289) [org.apache.helix.helix-core-1.4.3-dev-202502211050.jar:1.4.3-dev-202502211050]
        at org.apache.helix.controller.stages.BestPossibleStateCalcStage.process(BestPossibleStateCalcStage.java:94) [org.apache.helix.helix-core-1.4.3-dev-202502211050.jar:1.4.3-dev-202502211050]
        at org.apache.helix.controller.pipeline.Pipeline.handle(Pipeline.java:75) [org.apache.helix.helix-core-1.4.3-dev-202502211050.jar:1.4.3-dev-202502211050]
        at org.apache.helix.controller.GenericHelixController.handleEvent(GenericHelixController.java:905) [org.apache.helix.helix-core-1.4.3-dev-202502211050.jar:1.4.3-dev-202502211050]
        at org.apache.helix.controller.GenericHelixController$ClusterEventProcessor.run(GenericHelixController.java:1556) [org.apache.helix.helix-core-1.4.3-dev-202502211050.jar:1.4.3-dev-202502211050]
Caused by: java.util.ConcurrentModificationException
        at java.util.HashMap$EntrySpliterator.forEachRemaining(HashMap.java:1855) ~[?:?]
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[?:?]
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[?:?]
        at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921) ~[?:?]
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
        at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682) ~[?:?]
        at org.apache.helix.controller.rebalancer.waged.AssignmentManager.getBestPossibleAssignment(AssignmentManager.java:92) ~[org.apache.helix.helix-core-1.4.3-dev-202502211050.jar:1.4.3-dev-202502211050]
        ... 10 more
```