### PR TITLE
[TEST PR] skip min active check if instance replica in unhealthy state

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/ParticipantDeregistrationStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/ParticipantDeregistrationStage.java
@@ -26,14 +26,14 @@ public class ParticipantDeregistrationStage extends AbstractAsyncBaseStage {
   @Override
   public void execute(ClusterEvent event) throws Exception {
     HelixManager manager = event.getAttribute(AttributeName.helixmanager.name());
-    ClusterConfig clusterConfig = manager.getConfigAccessor().getClusterConfig(manager.getClusterName());
+    ResourceControllerDataProvider cache = event.getAttribute(AttributeName.ControllerDataProvider.name());
+    ClusterConfig clusterConfig = cache.getClusterConfig();
     if (clusterConfig == null || !clusterConfig.isParticipantDeregistrationEnabled()) {
       LOG.debug("Cluster config is null or participant deregistration is not enabled. "
           + "Skipping participant deregistration.");
       return;
     }
 
-    ResourceControllerDataProvider cache = event.getAttribute(AttributeName.ControllerDataProvider.name());
     Map<String, Long> offlineTimeMap = cache.getInstanceOfflineTimeMap();
     long deregisterDelay = clusterConfig.getParticipantDeregistrationTimeout();
     long stageStartTime = System.currentTimeMillis();

--- a/helix-core/src/main/java/org/apache/helix/util/InstanceValidationUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/InstanceValidationUtil.java
@@ -449,6 +449,11 @@ public class InstanceValidationUtil {
         Map<String, String> stateByInstanceMap = externalView.getStateMap(partition);
         // found the resource hosted on the instance
         if (stateByInstanceMap.containsKey(instanceName)) {
+          // If this node's replica is in unhealthy state, skip the sibling check as removing this replica will not
+          // negatively affect availability.
+          if (unhealthyStates.contains(stateByInstanceMap.get(instanceName))) {
+            continue;
+          }
           int numHealthySiblings = 0;
           for (Map.Entry<String, String> entry : stateByInstanceMap.entrySet()) {
             String siblingInstanceName = entry.getKey();

--- a/helix-core/src/test/java/org/apache/helix/integration/TestWagedNPE.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestWagedNPE.java
@@ -2,13 +2,10 @@ package org.apache.helix.integration;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import org.apache.helix.ConfigAccessor;
 import org.apache.helix.TestHelper;
 import org.apache.helix.common.ZkTestBase;
-import org.apache.helix.controller.rebalancer.DelayedAutoRebalancer;
-import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
 import org.apache.helix.controller.rebalancer.waged.WagedRebalancer;
 import org.apache.helix.integration.manager.ClusterControllerManager;
 import org.apache.helix.integration.manager.MockParticipantManager;

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
@@ -426,7 +426,7 @@ public class TestInstancesAccessor extends AbstractTestClass {
     JsonNode jsonResult = OBJECT_MAPPER.readTree(response.readEntity(String.class));
     Assert.assertFalse(jsonResult.get("stoppable").asBoolean());
     Assert.assertEquals(getStringSet(jsonResult, "failedChecks"),
-            ImmutableSet.of("HELIX:HAS_DISABLED_PARTITION","HELIX:INSTANCE_NOT_ENABLED","HELIX:INSTANCE_NOT_STABLE","HELIX:MIN_ACTIVE_REPLICA_CHECK_FAILED"));
+            ImmutableSet.of("HELIX:HAS_DISABLED_PARTITION","HELIX:INSTANCE_NOT_ENABLED","HELIX:INSTANCE_NOT_STABLE"));
 
     // Reenable instance0, it should passed the check
     instanceConfig.setInstanceOperation(InstanceConstants.InstanceOperation.ENABLE);


### PR DESCRIPTION
skip min active sibling check for any partition where the instance's replica is already in an unhealthy state. This is because removing that replica would not negatively affect availability of the partition. 

This prevents cases where:
Partition_1 {
node A: error,
node B: error,
node C: error
}

Node a cannot be stopped as there is not min active replicas satisfied. However, removing an error state partition does not reduce the partition's availability. We should only check for min active if the replica is in a healthy state and removing it would reduce availability. 