### PR TITLE
Allow for different CRUSH bucket types and add straw2

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/model/IdealState.java
+++ b/helix-core/src/main/java/org/apache/helix/model/IdealState.java
@@ -70,7 +70,8 @@ public class IdealState extends HelixProperty {
     RESOURCE_GROUP_NAME,
     RESOURCE_TYPE,
     GROUP_ROUTING_ENABLED,
-    EXTERNAL_VIEW_DISABLED
+    EXTERNAL_VIEW_DISABLED,
+    CRUSH_BUCKET_TYPE
   }
 
   public static final String QUERY_LIST = "PREFERENCE_LIST_QUERYS";
@@ -555,7 +556,7 @@ public class IdealState extends HelixProperty {
 
   /**
    * Get the number of replicas for each partition of this resource. Return value can be "ANY_LIVEINSTANCE", use
-   * {@link #getReplicaCount(int)} to prevent NumberFormatException when parsing string for int. 
+   * {@link #getReplicaCount(int)} to prevent NumberFormatException when parsing string for int.
    * @return String value of the replica count,
    */
   public String getReplicas() {
@@ -650,6 +651,21 @@ public class IdealState extends HelixProperty {
    */
   public long getRebalanceTimerPeriod() {
     return _record.getLongField(IdealStateProperty.REBALANCE_TIMER_PERIOD.toString(), -1);
+  }
+
+  /**
+   * Set the bucket type used by the CRUSH rebalance strategy
+   */
+  public void setCrushBucketType(String crushBucketType) {
+    _record.setSimpleField(IdealStateProperty.CRUSH_BUCKET_TYPE.toString(), crushBucketType);
+  }
+
+  /**
+   * Get the bucket type used by the CRUSH rebalance strategy
+   * @return the bucket type, or null if none is set
+   */
+  public String getCrushBucketType() {
+    return _record.getSimpleField(IdealStateProperty.CRUSH_BUCKET_TYPE.toString());
   }
 
   @Override


### PR DESCRIPTION
add straw2 and allow for future bucket types to be added

Benefit of straw2:
"There were problems with the internal weights calculated and stored in the CRUSH map for straw algorithm buckets. When there were buckets with a CRUSH weight of 0 or with a mix of different and unique weights, CRUSH would distribute data incorrectly (that is, not in proportion to the weights)."

Migration straw --> straw2: 
"Changing a bucket type from straw to straw2 will trigger a small amount of data movement, depending on how much the bucket items’ weights vary from each other. When the weights are all the same no data will move, and the more variance there is in the weights the more movement there will be."

https://docs.ceph.com/en/reef/rados/operations/crush-map/